### PR TITLE
Fix final stream stats start time

### DIFF
--- a/stats_bot.py
+++ b/stats_bot.py
@@ -477,17 +477,23 @@ class StatsBot(commands.Bot):
         from main import app
 
         with app.app_context():
-            rows = (
+            last = (
                 TimeSeries.query
                 .filter_by(stream_name=chan)
-                .order_by(TimeSeries.id)
-                .all()
+                .order_by(TimeSeries.id.desc())
+                .first()
             )
-            if not rows:
+            if not last:
                 return
 
-            first = rows[0]
-            last  = rows[-1]
+            first = (
+                TimeSeries.query
+                .filter_by(stream_name=chan, stream_date=last.stream_date)
+                .order_by(TimeSeries.id)
+                .first()
+            )
+            if not first:
+                return
 
             # sentiment stats across all snapshots
             avg_sent, min_sent, max_sent = db.session.query(


### PR DESCRIPTION
## Summary
- restrict stream-end queries to the current stream date so final stats use the correct start time

## Testing
- `python -m py_compile stats_bot.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb9783852483228a1b45226a180498